### PR TITLE
Add functionality to control explosions within defend zones

### DIFF
--- a/src/main/java/settlementexpansion/inventory/event/SettlementModDataUpdateEvent.java
+++ b/src/main/java/settlementexpansion/inventory/event/SettlementModDataUpdateEvent.java
@@ -11,12 +11,14 @@ public class SettlementModDataUpdateEvent extends ContainerEvent {
     public final boolean isServerClient;
     public final boolean isPvpFlagged;
     public final boolean isSettlementSafe;
+    public final boolean doExplosionDamage;
     public final boolean shouldStartCooldown;
 
     public SettlementModDataUpdateEvent(SettlementModData data, ServerClient client, boolean shouldStartCooldown, boolean isSettlementSafe) {
         this.isServerClient = client.isServer();
         this.isPvpFlagged = data.isPvpFlagged;
         this.isSettlementSafe = isSettlementSafe;
+        this.doExplosionDamage = data.doExplosionDamage;
         this.shouldStartCooldown = shouldStartCooldown;
     }
 
@@ -24,6 +26,7 @@ public class SettlementModDataUpdateEvent extends ContainerEvent {
         this.isServerClient = reader.getNextBoolean();
         this.isPvpFlagged = reader.getNextBoolean();
         this.isSettlementSafe = reader.getNextBoolean();
+        this.doExplosionDamage = reader.getNextBoolean();
         this.shouldStartCooldown = reader.getNextBoolean();
     }
 
@@ -32,6 +35,7 @@ public class SettlementModDataUpdateEvent extends ContainerEvent {
         writer.putNextBoolean(this.isServerClient);
         writer.putNextBoolean(this.isPvpFlagged);
         writer.putNextBoolean(this.isSettlementSafe);
+        writer.putNextBoolean(this.doExplosionDamage);
         writer.putNextBoolean(this.shouldStartCooldown);
     }
 }

--- a/src/main/java/settlementexpansion/inventory/form/SettlementModContainerForm.java
+++ b/src/main/java/settlementexpansion/inventory/form/SettlementModContainerForm.java
@@ -59,7 +59,7 @@ public class SettlementModContainerForm<T extends SettlementModContainer> extend
         this.menus.add(new SettlementEquipmentForm<>(client, container, this));
         this.menus.add(new SettlementDietsForm<>(client, container, this));
         this.menus.add(new SettlementRestrictForm<>(client, container, this));
-        this.menus.add(new SettlementDefendZoneForm<>(client, container, this));
+        this.menus.add(new SettlementModDefendZoneForm<>(client, container, this));
         this.menus.add(new SettlementWorkPrioritiesForm<>(client, container, this));
         this.menus.add(new SettlementAssignWorkForm<>(client, container, this));
 

--- a/src/main/java/settlementexpansion/inventory/form/SettlementModDefendZoneForm.java
+++ b/src/main/java/settlementexpansion/inventory/form/SettlementModDefendZoneForm.java
@@ -1,0 +1,43 @@
+package settlementexpansion.inventory.form;
+
+import necesse.engine.network.client.Client;
+import necesse.gfx.forms.components.FormComponent;
+import necesse.gfx.forms.components.FormFlow;
+import necesse.gfx.forms.components.FormHorizontalToggle;
+import necesse.gfx.forms.components.FormLabel;
+import necesse.gfx.forms.components.localComponents.FormLocalLabel;
+import necesse.gfx.forms.presets.containerComponent.settlement.SettlementContainerForm;
+import necesse.gfx.forms.presets.containerComponent.settlement.SettlementDefendZoneForm;
+import necesse.gfx.gameFont.FontOptions;
+import settlementexpansion.inventory.container.SettlementModContainer;
+import settlementexpansion.inventory.event.SettlementModDataUpdateEvent;
+
+public class SettlementModDefendZoneForm<T extends SettlementModContainer> extends SettlementDefendZoneForm<T> {
+    private final FormHorizontalToggle explosionDamageToggle;
+
+    public SettlementModDefendZoneForm(Client client, T container, SettlementContainerForm<T> containerForm) {
+        super(client, container, containerForm);
+        FormFlow flow = new FormFlow(getHeight());
+        int toggleX = 0;
+        int labelX = 0;
+        for (FormComponent comp : getComponents()) {
+            if (comp instanceof FormHorizontalToggle) {
+                toggleX = ((FormHorizontalToggle) comp).getX();
+            } else if (comp instanceof FormLocalLabel) {
+                labelX = ((FormLocalLabel) comp).getX();
+            }
+        }
+
+        FormLocalLabel label = addComponent(flow.nextY(new FormLocalLabel("ui", "settlementexplosiondamage", new FontOptions(16), FormLabel.ALIGN_LEFT, labelX, flow.next(), getWidth() - 60), 10));
+        explosionDamageToggle = addComponent(new FormHorizontalToggle(toggleX, label.getY() + label.getHeight() / 2 - 8));
+        explosionDamageToggle.onToggled(e -> container.setExplosionDamage.runAndSend(e.from.isToggled()));
+
+        setHeight(flow.next());
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        container.onEvent(SettlementModDataUpdateEvent.class, e -> explosionDamageToggle.setToggled(e.doExplosionDamage));
+    }
+}

--- a/src/main/java/settlementexpansion/map/settlement/SettlementModData.java
+++ b/src/main/java/settlementexpansion/map/settlement/SettlementModData.java
@@ -9,16 +9,19 @@ import settlementexpansion.SettlementExpansion;
 public class SettlementModData extends LevelData {
 
     public boolean isPvpFlagged;
+    public boolean doExplosionDamage;
     public SettlementModRoomsManager rooms;
 
     public SettlementModData() {
         this.isPvpFlagged = false;
+        this.doExplosionDamage = true;
         this.rooms = new SettlementModRoomsManager(this);
     }
 
     public void addSaveData(SaveData save) {
         super.addSaveData(save);
         save.addBoolean("settlementPvpFlagged", this.isPvpFlagged);
+        save.addBoolean("settlementExplosionDamage", this.doExplosionDamage);
     }
 
     public void applyLoadData(LoadData save) {
@@ -27,6 +30,7 @@ public class SettlementModData extends LevelData {
         if (this.level.getWorldSettings().forcedPvP) {
             this.isPvpFlagged = SettlementExpansion.getSettings().enableSettlementLevelModification;
         }
+        this.doExplosionDamage = save.getBoolean("settlementExplosionDamage");
     }
 
 
@@ -44,6 +48,10 @@ public class SettlementModData extends LevelData {
         } else {
             this.isPvpFlagged = this.level.getWorldSettings().forcedPvP;
         }
+    }
+
+    public void setExplosionDamage(boolean doExplosionDamage) {
+        this.doExplosionDamage = doExplosionDamage;
     }
 
     public static void createSettlementModDataCreateIfNonExist(Level level) {
@@ -80,5 +88,4 @@ public class SettlementModData extends LevelData {
     public void setLevel(Level level) {
         super.setLevel(level);
     }
-
 }

--- a/src/main/java/settlementexpansion/patch/GameObjectPatch.java
+++ b/src/main/java/settlementexpansion/patch/GameObjectPatch.java
@@ -1,0 +1,25 @@
+package settlementexpansion.patch;
+
+import necesse.engine.modLoader.annotations.ModMethodPatch;
+import necesse.engine.network.server.ServerClient;
+import necesse.level.gameObject.GameObject;
+import necesse.level.maps.Level;
+import necesse.level.maps.levelData.settlementData.SettlementLevelData;
+import net.bytebuddy.asm.Advice;
+import settlementexpansion.map.settlement.SettlementModData;
+
+public class GameObjectPatch {
+    @ModMethodPatch(target = GameObject.class, name = "doExplosionDamage", arguments = {Level.class,
+            int.class, int.class, int.class, int.class, ServerClient.class})
+    public static class DoExplosionDamagePatch {
+        @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+        static boolean onExit(@Advice.AllArguments Object[] args) {
+            Level level = (Level) args[0];
+            int x = (int) args[1];
+            int y = (int) args[2];
+            SettlementModData data = SettlementModData.getSettlementModData(level);
+            SettlementLevelData settlementData = SettlementLevelData.getSettlementData(level);
+            return level.settlementLayer.isActive() && !data.doExplosionDamage && settlementData.getDefendZone().containsTile(x, y);
+        }
+    }
+}

--- a/src/main/java/settlementexpansion/patch/GameTilePatch.java
+++ b/src/main/java/settlementexpansion/patch/GameTilePatch.java
@@ -1,0 +1,25 @@
+package settlementexpansion.patch;
+
+import necesse.engine.modLoader.annotations.ModMethodPatch;
+import necesse.engine.network.server.ServerClient;
+import necesse.level.gameTile.GameTile;
+import necesse.level.maps.Level;
+import necesse.level.maps.levelData.settlementData.SettlementLevelData;
+import net.bytebuddy.asm.Advice;
+import settlementexpansion.map.settlement.SettlementModData;
+
+public class GameTilePatch {
+    @ModMethodPatch(target = GameTile.class, name = "doExplosionDamage", arguments = {Level.class,
+            int.class, int.class, int.class, int.class, ServerClient.class})
+    public static class DoExplosionDamagePatch {
+        @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+        static boolean onExit(@Advice.AllArguments Object[] args) {
+            Level level = (Level) args[0];
+            int x = (int) args[1];
+            int y = (int) args[2];
+            SettlementModData data = SettlementModData.getSettlementModData(level);
+            SettlementLevelData settlementData = SettlementLevelData.getSettlementData(level);
+            return level.settlementLayer.isActive() && !data.doExplosionDamage && settlementData.getDefendZone().containsTile(x, y);
+        }
+    }
+}

--- a/src/main/resources/locale/en.lang
+++ b/src/main/resources/locale/en.lang
@@ -89,6 +89,7 @@ settlementconfirmnotice=Are you sure?
 settlementunclaimexplain=Unclaiming a settlement will leave it unmanaged, vulnerable to attacks and to everyone else to claim
 settlementdestroyexplain=Destroying a flag will remove your claim to the settlement and allow others to place their own flags
 settlementpvpexplain=Enabling Settlement PvP will allow all players to build, destroy and steal from your settlement\nYou can disable it only after 5 minutes
+settlementexplosiondamage=Explosions within defend zone will damage tiles and objects
 settlementdestroyflag=Destroy Flag
 settlementdestroybutton=Destroy
 settlementtakeover=Take over Settlement


### PR DESCRIPTION
Porting the functionality from Hardened Settlements. I have also moved the configuration button from the general settlement settings menu into the defend zone menu.

![defendZoneSettings](https://github.com/Vierdant/SettlementExpansion/assets/125102019/3cda3659-6372-4e03-b197-fde71754e2f6)
